### PR TITLE
Add options to httparty

### DIFF
--- a/lib/client.rb
+++ b/lib/client.rb
@@ -28,16 +28,16 @@ module TotalVoice
     #   - +Access-Token+ -> Access-Token TotalVoice
     #   - +host+ -> Base URL para API
     #
-    def initialize(access_token, host = nil)
+    def initialize(access_token, host = nil, options = {})
       @access_token     = access_token
       @host             = host ? host : ENDPOINT
       @options = {
         headers: {
-          "Access-Token" => @access_token,
-          "Content-Type" => "application/json",
-          "Accept" => "application/json"
+          'Access-Token' => @access_token,
+          'Content-Type' => 'application/json',
+          'Accept' => 'application/json'
         }
-      }
+      }.merge(options)
 
       @audio = nil
       @bina = nil


### PR DESCRIPTION
Atualmente temos casos onde alguns requests levam 2 minutos até a API retornar timeout.

![](https://trello-attachments.s3.amazonaws.com/5cbe03fdbbde76415f142056/60535dfac9483e5159b0a000/ea1770d7329a041b7ea70270f521e0ff/image_(9).png)

Este PR esta relacionado a issue #12 e tem a finalidade de possibilitar aos usuários da gem definirem o tempo que desejam esperar pela resposta da API.